### PR TITLE
feat: save draggingEnabled between reload

### DIFF
--- a/src/FileOrderManager.ts
+++ b/src/FileOrderManager.ts
@@ -16,7 +16,7 @@ import ManualSortingPlugin from './main';
 export class FileOrderManager {
 	private _customFileOrder: FileOrder;
 
-    constructor(private plugin: ManualSortingPlugin) {}
+	constructor(private plugin: ManualSortingPlugin) { }
 
 	/**
 	 * Saves the custom file order to the plugin's data storage.
@@ -26,13 +26,13 @@ export class FileOrderManager {
 	 * Preloading previously saved data is avoided to save time.
 	 */
 	private async _saveCustomOrder() {
-		const data: PluginData = {customFileOrder: {}};
+		const data: PluginData = { customFileOrder: {}, draggingEnabled: this.plugin.draggingEnabled };
 		data.customFileOrder = this._customFileOrder;
 		await this.plugin.saveData(data);
 	}
-	
+
 	private async _loadCustomOrder() {
-		const defaultOrder = {customFileOrder: {"/": []}};
+		const defaultOrder = { customFileOrder: { "/": [] } };
 		const data = Object.assign({}, defaultOrder, await this.plugin.loadData());
 		await this._migrateDataToNewFormat(data);
 		this._customFileOrder = data.customFileOrder;
@@ -42,10 +42,10 @@ export class FileOrderManager {
 	private async _migrateDataToNewFormat(data: PluginData) {
 		const keys = Object.keys(data);
 		const otherKeys = keys.filter(key => key !== 'customFileOrder');
-		
+
 		if (otherKeys.length > 0) {
 			for (const key of otherKeys) {
-				data.customFileOrder[key] = data[key] ;
+				data.customFileOrder[key] = data[key];
 				delete data[key];
 			}
 		}
@@ -57,7 +57,7 @@ export class FileOrderManager {
 	}
 
 	resetOrder() {
-		this._customFileOrder = {"/": []};
+		this._customFileOrder = { "/": [] };
 		this._saveCustomOrder();
 	}
 
@@ -71,26 +71,26 @@ export class FileOrderManager {
 		console.log("Order updated:", this._customFileOrder);
 	}
 
-    private async _getCurrentOrder() {
+	private async _getCurrentOrder() {
 		const currentData: { [folderPath: string]: string[] } = {};
-        const explorerView = this.plugin.app.workspace.getLeavesOfType("file-explorer")[0]?.view as FileExplorerView;
+		const explorerView = this.plugin.app.workspace.getLeavesOfType("file-explorer")[0]?.view as FileExplorerView;
 
-        const indexFolder = (folder: TFolder) => {
-            const sortedItems = explorerView.getSortedFolderItems(folder);
-            const sortedItemPaths = sortedItems.map((item) => item.file.path);
-            currentData[folder.path] = sortedItemPaths;
+		const indexFolder = (folder: TFolder) => {
+			const sortedItems = explorerView.getSortedFolderItems(folder);
+			const sortedItemPaths = sortedItems.map((item) => item.file.path);
+			currentData[folder.path] = sortedItemPaths;
 
-            for (const item of sortedItems) {
-                const itemObject = item.file;
-                if (itemObject instanceof TFolder) {
-                    indexFolder(itemObject);
-                }
-            }
-        };
+			for (const item of sortedItems) {
+				const itemObject = item.file;
+				if (itemObject instanceof TFolder) {
+					indexFolder(itemObject);
+				}
+			}
+		};
 
-        indexFolder(this.plugin.app.vault.root);
-        return currentData;
-    }
+		indexFolder(this.plugin.app.vault.root);
+		return currentData;
+	}
 
 	private async _matchSavedOrder(currentOrder: FileOrder, savedOrder: FileOrder) {
 		let result: FileOrder = {};
@@ -192,7 +192,7 @@ export class FileOrderManager {
 	getFlattenPaths() {
 		function flattenPaths(obj: { [key: string]: string[] }, path: string = "/"): string[] {
 			let result = [];
-			
+
 			if (obj[path]) {
 				for (const item of obj[path]) {
 					result.push(item);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -3,6 +3,7 @@ import { TAbstractFile } from "obsidian";
 
 export interface PluginData {
 	customFileOrder: FileOrder;
+	draggingEnabled: boolean;
 	[otherKey: string]: any;
 }
 


### PR DESCRIPTION
This pull request introduces a new feature to persist the state of the `draggingEnabled` property in the `ManualSortingPlugin`, ensuring that the dragging functionality's state is saved and restored across plugin reloads. It also refactors the code to replace the private `_draggingEnabled` property with a public `draggingEnabled` property for better accessibility and maintainability.

### New Feature: Persisting `draggingEnabled` State
* Added a new `draggingEnabled` property to the `PluginData` object, which is saved and loaded alongside the existing `customFileOrder` data. (`src/FileOrderManager.ts`, `src/main.ts`) [[1]](diffhunk://#diff-be9a79991f78d47fca850dab2f3d90dab497cda52b885bdbbd4a26c8fa09afeaL29-R29) [[2]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR35-R39)
* Implemented the `_loadDragging` method to initialize the `draggingEnabled` property from saved plugin data, defaulting to `true` if no value is found. (`src/main.ts`)

### Refactoring: Replacing `_draggingEnabled` with `draggingEnabled`
* Replaced all occurrences of the private `_draggingEnabled` property with the public `draggingEnabled` property to simplify access and usage. (`src/main.ts`) [[1]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR7-R13) [[2]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL51-R60) [[3]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL119-R127) [[4]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR210) [[5]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL291-R300) [[6]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL352-R361) [[7]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL556-R565) [[8]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL570-R586)

### Behavior Updates
* Updated the `toogleDragging` method to save the updated `draggingEnabled` state to plugin data whenever toggled. (`src/main.ts`)
* Ensured that the draggable state of elements in the file explorer reflects the current value of `draggingEnabled`. (`src/main.ts`) [[1]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR210) [[2]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL291-R300)

These changes improve the user experience by preserving the dragging state across sessions and streamline the codebase by consolidating the handling of the `draggingEnabled` property.

close #38 